### PR TITLE
fix: ignore system symlink

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.0
+    gravitee: gravitee-io/gravitee@2.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-= GIT Fetcher
+= Git Fetcher
 
 ifdef::env-github[]
 image:https://img.shields.io/static/v1?label=Available%20at&message=Gravitee.io&color=1EC9D2["Gravitee.io", link="https://download.gravitee.io/#graviteeio-apim/plugins/fetchers/gravitee-fetcher-git/"]
@@ -11,14 +11,7 @@ endif::[]
 
 == Documentation
 
-This plugin allow Gravitee.io to fetch content from a git repository.
+This plugin allow Gravitee.io to fetch content from a Git repository.
 It's primarily used to fetch documentation.
 
-**Authentications is currently not supported**.
-
-== Cautions
-This plugin is based on https://eclipse.org/jgit/[JGit].
-The current version of JGit (5.1.0.201809111528-r) doesn't support shallow clones (https://bugs.eclipse.org/bugs/show_bug.cgi?id=475615).
-This means that the entire repository is cloned in a temporary folder.
-
-This could take some times and spaces on your device.
+**Authentication is currently not supported**.

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.fetcher</groupId>
     <artifactId>gravitee-fetcher-git</artifactId>
-    <version>1.8.0</version>
+    <version>1.7.0</version>
 
     <name>Gravitee.io APIM - Fetcher - GIT</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>15</version>
+        <version>20.5</version>
     </parent>
 
     <groupId>io.gravitee.fetcher</groupId>
@@ -34,14 +34,26 @@
     <name>Gravitee.io APIM - Fetcher - GIT</name>
 
     <properties>
+        <gravitee-bom.version>2.8</gravitee-bom.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
-        <junit.version>4.13.1</junit.version>
-        <assertj-core.version>3.5.1</assertj-core.version>
-        <org.eclipse.jgit.version>5.1.0.201809111528-r</org.eclipse.jgit.version>
+        <maven-assembly-plugin.version>3.4.1</maven-assembly-plugin.version>
+        <org.eclipse.jgit.version>6.3.0.202209071007-r</org.eclipse.jgit.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/fetchers</publish-folder-path>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Import bom to properly inherit all dependencies -->
+            <dependency>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -59,7 +71,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>${spring.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -72,14 +83,11 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <!-- use 2.5.0 for Java 7 projects -->
-            <version>${assertj-core.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,11 @@
     <properties>
         <gravitee-bom.version>2.8</gravitee-bom.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <maven-assembly-plugin.version>3.4.1</maven-assembly-plugin.version>
         <org.eclipse.jgit.version>6.3.0.202209071007-r</org.eclipse.jgit.version>
+
+        <maven-exec-plugin.version>3.1.0</maven-exec-plugin.version>
+        <maven-assembly-plugin.version>3.4.1</maven-assembly-plugin.version>
+
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/fetchers</publish-folder-path>
     </properties>
@@ -136,6 +139,35 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <!-- ⚠️ This plugin in used to remove a Git section forcing SSH connection instead of HTTPS  -->
+                <!-- on CircleCI, for extra info see https://discuss.circleci.com/t/github-forced-through-ssh-protocol/5332 -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${maven-exec-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skip>${env.CIRCLECI == null}</skip>
+                    <executable>git</executable>
+                    <arguments>
+                        <argument>config</argument>
+                        <argument>--global</argument>
+                        <argument>--remove-section</argument>
+                        <argument>url.ssh://git@github.com</argument>
+                    </arguments>
+                    <successCodes>
+                        <successCode>0</successCode>
+                        <successCode>1</successCode>
+                    </successCodes>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/io/gravitee/fetcher/git/GitFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/git/GitFetcher.java
@@ -73,6 +73,7 @@ public class GitFetcher implements Fetcher {
                 .setURI(this.gitFetcherConfiguration.getRepository())
                 .setDirectory(tmpDirectory)
                 .setBranch(this.gitFetcherConfiguration.getBranchOrTag())
+                .setDepth(1)
                 .call()
         ) {
             LOGGER.debug("Having repository: {}", result.getRepository().getDirectory());

--- a/src/main/java/io/gravitee/fetcher/git/GitFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/git/GitFetcher.java
@@ -23,7 +23,7 @@ import java.io.*;
 import org.eclipse.jgit.api.Git;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.scheduling.support.CronSequenceGenerator;
+import org.springframework.scheduling.support.CronExpression;
 
 /**
  * @author Nicolas GERAUD (nicolas <AT> graviteesource.com)
@@ -31,8 +31,8 @@ import org.springframework.scheduling.support.CronSequenceGenerator;
  */
 public class GitFetcher implements Fetcher {
 
-    private final Logger LOGGER = LoggerFactory.getLogger(GitFetcher.class);
-    private GitFetcherConfiguration gitFetcherConfiguration;
+    private static final Logger LOGGER = LoggerFactory.getLogger(GitFetcher.class);
+    private final GitFetcherConfiguration gitFetcherConfiguration;
 
     public GitFetcher(GitFetcherConfiguration gitFetcherConfiguration) {
         this.gitFetcherConfiguration = gitFetcherConfiguration;
@@ -49,13 +49,13 @@ public class GitFetcher implements Fetcher {
 
         if (gitFetcherConfiguration.isAutoFetch() && gitFetcherConfiguration.getFetchCron() != null) {
             try {
-                new CronSequenceGenerator(gitFetcherConfiguration.getFetchCron());
+                CronExpression.parse(gitFetcherConfiguration.getFetchCron());
             } catch (IllegalArgumentException e) {
                 throw new FetcherException("Cron expression is invalid", e);
             }
         }
 
-        File localPath = null;
+        File localPath;
         try {
             localPath = File.createTempFile("Gravitee-io", "");
             localPath.delete();
@@ -76,7 +76,7 @@ public class GitFetcher implements Fetcher {
             File fileToFetch = new File(
                 result.getRepository().getWorkTree().getAbsolutePath() + File.separatorChar + gitFetcherConfiguration.getPath()
             );
-            result.close();
+
             final Resource resource = new Resource();
             resource.setContent(new FileInputStream(fileToFetch));
             return resource;

--- a/src/test/java/io/gravitee/fetcher/git/GitFetcherIntegrationTest.java
+++ b/src/test/java/io/gravitee/fetcher/git/GitFetcherIntegrationTest.java
@@ -28,13 +28,13 @@ import org.junit.Test;
  * @author Nicolas GERAUD (nicolas <AT> graviteesource.com)
  * @author GraviteeSource Team
  */
-public class GitFetcherTest {
+public class GitFetcherIntegrationTest {
 
     @Test
     public void shouldGetExistingFileWithBranch() throws Exception {
         GitFetcherConfiguration gitFetcherConfiguration = new GitFetcherConfiguration();
-        gitFetcherConfiguration.setRepository("git://github.com/gravitee-io/gravitee-fetcher-api.git");
-        gitFetcherConfiguration.setBranchOrTag("1.4.x");
+        gitFetcherConfiguration.setRepository("https://github.com/gravitee-io/gravitee-fetcher-git");
+        gitFetcherConfiguration.setBranchOrTag("master");
         gitFetcherConfiguration.setPath("pom.xml");
 
         GitFetcher gitFetcher = new GitFetcher(gitFetcherConfiguration);
@@ -42,19 +42,19 @@ public class GitFetcherTest {
         assertThat(is).isNotNull();
         BufferedReader br = new BufferedReader(new InputStreamReader(is));
         String line;
-        String content = "";
+        StringBuilder content = new StringBuilder();
         while ((line = br.readLine()) != null) {
-            content += line;
+            content.append(line);
             assertThat(line).isNotNull();
         }
         br.close();
-        assertThat(content).contains("<name>Gravitee.io APIM - Fetcher - API</name>");
+        assertThat(content.toString()).contains("<name>Gravitee.io APIM - Fetcher - GIT</name>");
     }
 
     @Test
     public void shouldGetExistingFileWithTag() throws Exception {
         GitFetcherConfiguration gitFetcherConfiguration = new GitFetcherConfiguration();
-        gitFetcherConfiguration.setRepository("git://github.com/gravitee-io/gravitee-fetcher-api.git");
+        gitFetcherConfiguration.setRepository("https://github.com/gravitee-io/gravitee-fetcher-git");
         gitFetcherConfiguration.setBranchOrTag("1.4.0");
         gitFetcherConfiguration.setPath("pom.xml");
 
@@ -63,19 +63,19 @@ public class GitFetcherTest {
         assertThat(is).isNotNull();
         BufferedReader br = new BufferedReader(new InputStreamReader(is));
         String line;
-        String content = "";
+        StringBuilder content = new StringBuilder();
         while ((line = br.readLine()) != null) {
-            content += line;
+            content.append(line);
             assertThat(line).isNotNull();
         }
         br.close();
-        assertThat(content).contains("<version>1.4.0</version>");
+        assertThat(content.toString()).contains("<version>1.4.0</version>");
     }
 
     @Test
-    public void shouldGetInexistingPath() throws Exception {
+    public void shouldGetInexistingPath() {
         GitFetcherConfiguration gitFetcherConfiguration = new GitFetcherConfiguration();
-        gitFetcherConfiguration.setRepository("git://github.com/gravitee-io/gravitee-fetcher-api.git");
+        gitFetcherConfiguration.setRepository("https://github.com/gravitee-io/gravitee-fetcher-git");
         gitFetcherConfiguration.setBranchOrTag("master");
         gitFetcherConfiguration.setPath("unknown");
 
@@ -91,7 +91,7 @@ public class GitFetcherTest {
     }
 
     @Test
-    public void shouldGetInexistingRepo() throws Exception {
+    public void shouldGetInexistingRepo() {
         GitFetcherConfiguration gitFetcherConfiguration = new GitFetcherConfiguration();
         gitFetcherConfiguration.setRepository("git://unknown/gravitee-io/gravitee-fetcher-api.git");
         gitFetcherConfiguration.setBranchOrTag("master");
@@ -109,9 +109,9 @@ public class GitFetcherTest {
     }
 
     @Test
-    public void shouldGetInexistingBranch() throws Exception {
+    public void shouldGetInexistingBranch() {
         GitFetcherConfiguration gitFetcherConfiguration = new GitFetcherConfiguration();
-        gitFetcherConfiguration.setRepository("git://github.com/gravitee-io/gravitee-fetcher-api.git");
+        gitFetcherConfiguration.setRepository("https://github.com/gravitee-io/gravitee-fetcher-git");
         gitFetcherConfiguration.setBranchOrTag("munster");
         gitFetcherConfiguration.setPath("README.md");
 

--- a/src/test/java/io/gravitee/fetcher/git/GitFetcherIntegrationTest.java
+++ b/src/test/java/io/gravitee/fetcher/git/GitFetcherIntegrationTest.java
@@ -125,4 +125,43 @@ public class GitFetcherIntegrationTest {
             assertThat(is).isNull();
         }
     }
+
+    @Test
+    public void shouldThrowWhenUsingForbiddenSymlink() {
+        GitFetcherConfiguration gitFetcherConfiguration = new GitFetcherConfiguration();
+        gitFetcherConfiguration.setRepository("https://github.com/gravitee-io/gravitee-fetcher-git");
+        gitFetcherConfiguration.setBranchOrTag("fix/#244-ignore-system-symlink");
+        // Symlink is pointing to /etc/host
+        gitFetcherConfiguration.setPath("src/test/resources/symlink.txt");
+
+        GitFetcher gitFetcher = new GitFetcher(gitFetcherConfiguration);
+        InputStream is = null;
+        try {
+            is = gitFetcher.fetch().getContent();
+            fail("should not happen");
+        } catch (FetcherException fetcherException) {
+            assertThat(fetcherException.getMessage())
+                .isEqualTo("Accessing a file outside the Git repository using symbolic links is not allowed");
+            assertThat(is).isNull();
+        }
+    }
+
+    @Test
+    public void shouldThrowWhenUsingInvalidCronExpression() {
+        GitFetcherConfiguration gitFetcherConfiguration = new GitFetcherConfiguration();
+        gitFetcherConfiguration.setRepository("https://github.com/gravitee-io/gravitee-fetcher-git");
+        gitFetcherConfiguration.setBranchOrTag("fix/#244-ignore-system-symlink");
+        gitFetcherConfiguration.setAutoFetch(true);
+        gitFetcherConfiguration.setFetchCron("invalid-cron");
+
+        GitFetcher gitFetcher = new GitFetcher(gitFetcherConfiguration);
+        InputStream is = null;
+        try {
+            is = gitFetcher.fetch().getContent();
+            fail("should not happen");
+        } catch (FetcherException fetcherException) {
+            assertThat(fetcherException.getMessage()).isEqualTo("Cron expression is invalid");
+            assertThat(is).isNull();
+        }
+    }
 }

--- a/src/test/resources/symlink.txt
+++ b/src/test/resources/symlink.txt
@@ -1,0 +1,1 @@
+/etc/hosts


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/244

**Description**

Forbid users to use symbolic links which are pointing files outside of the git repository
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.8.0-fix-244-ignore-system-symlink-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/fetcher/gravitee-fetcher-git/1.8.0-fix-244-ignore-system-symlink-SNAPSHOT/gravitee-fetcher-git-1.8.0-fix-244-ignore-system-symlink-SNAPSHOT.zip)
  <!-- Version placeholder end -->
