### PR TITLE
chore: update dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,8 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.1
+    gravitee: gravitee-io/gravitee@4.1.0
+
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
@@ -22,7 +23,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_plugin-release-config:
@@ -32,4 +33,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,25 @@
 {
-  "extends": [
-    "config:base",
-    "schedule:earlyMondays"
-  ],
-  "prConcurrentLimit": 3,
+  "extends": ["config:base", ":label(dependencies)"],
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "ci"
+    },
+    {
+      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "chore"
+    },
+    {
+      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+      "matchUpdateTypes": ["major"],
+      "semanticCommitType": "chore"
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.5</version>
+        <version>21.0.1</version>
     </parent>
 
     <groupId>io.gravitee.fetcher</groupId>
@@ -34,7 +34,7 @@
     <name>Gravitee.io APIM - Fetcher - GIT</name>
 
     <properties>
-        <gravitee-bom.version>2.8</gravitee-bom.version>
+        <gravitee-bom.version>3.0.22</gravitee-bom.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <org.eclipse.jgit.version>6.3.0.202209071007-r</org.eclipse.jgit.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <org.eclipse.jgit.version>6.3.0.202209071007-r</org.eclipse.jgit.version>
 
-        <maven-exec-plugin.version>3.1.0</maven-exec-plugin.version>
-        <maven-assembly-plugin.version>3.4.1</maven-assembly-plugin.version>
+        <maven-exec-plugin.version>3.1.1</maven-exec-plugin.version>
+        <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
 
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/fetchers</publish-folder-path>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <gravitee-bom.version>3.0.22</gravitee-bom.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <org.eclipse.jgit.version>6.3.0.202209071007-r</org.eclipse.jgit.version>
+        <org.eclipse.jgit.version>6.8.0.202311291450-r</org.eclipse.jgit.version>
 
         <maven-exec-plugin.version>3.1.1</maven-exec-plugin.version>
         <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>


### PR DESCRIPTION
**Description**

Upgrade all Gravitee dependencies using the version defined in the latest 3.20.
Upgrade jgit

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.8.2-bump-dependencies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/fetcher/gravitee-fetcher-git/1.8.2-bump-dependencies-SNAPSHOT/gravitee-fetcher-git-1.8.2-bump-dependencies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
