### PR TITLE
Update fetcher for APIM 4.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ setup: true
 orbs:
     gravitee: gravitee-io/gravitee@4.1.1
 
-
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
 workflows:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,25 +1,3 @@
 {
-  "extends": ["config:base", ":label(dependencies)"],
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchDatasources": ["orb"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "ci"
-    },
-    {
-      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "chore"
-    },
-    {
-      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-      "matchUpdateTypes": ["major"],
-      "semanticCommitType": "chore"
-    }
-  ]
+    "extends": ["github>gravitee-io/renovate-config:lib"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,167 +1,39 @@
-# Created by .ignore support plugin (hsz.mobi)
-### OSX template
-*.DS_Store
-.AppleDouble
-.LSOverride
-
-# Icon must end with two \r
-Icon
-
-# Thumbnails
-._*
-
-# Files that might appear in the root of a volume
-.DocumentRevisions-V100
-.fseventsd
-.Spotlight-V100
-.TemporaryItems
-.Trashes
-.VolumeIcon.icns
-.com.apple.timemachine.donotpresent
-
-# Directories potentially created on remote AFP share
-.AppleDB
-.AppleDesktop
-Network Trash Folder
-Temporary Items
-.apdisk
-### Eclipse template
-
-.metadata
-bin/
-tmp/
-*.tmp
-*.bak
-*.swp
-*~.nib
-local.properties
-.settings/
-.loadpath
-.recommenders
-
-# Eclipse Core
-.project
-
-# External tool builders
-.externalToolBuilders/
-
-# Locally stored "Eclipse launch configurations"
-*.launch
-
-# PyDev specific (Python IDE for Eclipse)
-*.pydevproject
-
-# CDT-specific (C/C++ Development Tooling)
-.cproject
-
-# JDT-specific (Eclipse Java Development Tools)
-.classpath
-
-# Java annotation processor (APT)
-.factorypath
-
-# PDT-specific (PHP Development Tools)
-.buildpath
-
-# sbteclipse plugin
-.target
-
-# Tern plugin
-.tern-project
-
-# TeXlipse plugin
-.texlipse
-
-# STS (Spring Tool Suite)
-.springBeans
-
-# Code Recommenders
-.recommenders/
-### JetBrains template
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
-# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
-
-# User-specific stuff:
-.idea/workspace.xml
-.idea/tasks.xml
-.idea/dictionaries
-.idea/vcs.xml
-.idea/jsLibraryMappings.xml
-
-# Sensitive or high-churn files:
-.idea/dataSources.ids
-.idea/dataSources.xml
-.idea/dataSources.local.xml
-.idea/sqlDataSources.xml
-.idea/dynamic.xml
-.idea/uiDesigner.xml
-
-# Gradle:
-.idea/gradle.xml
-.idea/libraries
-
-# Mongo Explorer plugin:
-.idea/mongoSettings.xml
-
-## File-based project format:
-*.iws
-
-## Plugin-specific files:
-
-# IntelliJ
-/out/
-
-# mpeltonen/sbt-idea plugin
-.idea_modules/
-
-# JIRA plugin
-atlassian-ide-plugin.xml
-
-# Crashlytics plugin (for Android Studio and IntelliJ)
-com_crashlytics_export_strings.xml
-crashlytics.properties
-crashlytics-build.properties
-fabric.properties
-### Windows template
-# Windows image file caches
-Thumbs.db
-ehthumbs.db
-
-# Folder config file
-Desktop.ini
-
-# Recycle Bin used on file shares
-$RECYCLE.BIN/
-
-# Windows Installer files
-*.cab
-*.msi
-*.msm
-*.msp
-
-# Windows shortcuts
-*.lnk
-### Linux template
-*~
-
-# temporary files which can be created if a process still has a handle open of a deleted file
-.fuse_hidden*
-
-# KDE directory preferences
-.directory
-
-# Linux trash folder which might appear on any partition or disk
-.Trash-*
-
-### Maven template
 target/
-pom.xml.tag
-pom.xml.releaseBackup
-pom.xml.versionsBackup
-pom.xml.next
-release.properties
-dependency-reduced-pom.xml
-buildNumber.properties
-.mvn/timing.properties
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
 
-gravitee-fetcher-git.iml
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store
+/.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,12 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
 
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <maven-exec-plugin.version>3.3.0</maven-exec-plugin.version>
+        <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/fetchers</publish-folder-path>
     </properties>
@@ -119,6 +120,13 @@
         </resources>
 
         <plugins>
+            <!-- Force version of the plugin to avoid a bug: https://issues.apache.org/jira/browse/MRESOURCES-237 -->
+            <!-- https://stackoverflow.com/questions/40346225/maven-resources-plugin-symbolic-link-handling -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>${maven-resources-plugin.version}</version>
+            </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>${maven-assembly-plugin.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,23 +24,22 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.1</version>
+        <version>22.0.2</version>
     </parent>
 
     <groupId>io.gravitee.fetcher</groupId>
     <artifactId>gravitee-fetcher-git</artifactId>
-    <version>1.8.2</version>
+    <version>2.0.0-upgrade-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Fetcher - GIT</name>
 
     <properties>
-        <gravitee-bom.version>3.0.27</gravitee-bom.version>
-        <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
+        <gravitee-bom.version>6.0.39</gravitee-bom.version>
+        <gravitee-fetcher-api.version>2.0.0</gravitee-fetcher-api.version>
         <org.eclipse.jgit.version>6.8.0.202311291450-r</org.eclipse.jgit.version>
 
-        <maven-exec-plugin.version>3.3.0</maven-exec-plugin.version>
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
-
+        <maven-exec-plugin.version>3.3.0</maven-exec-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/fetchers</publish-folder-path>
     </properties>
@@ -59,6 +58,7 @@
     </dependencyManagement>
 
     <dependencies>
+        <!-- Gravitee.io -->
         <dependency>
             <groupId>io.gravitee.fetcher</groupId>
             <artifactId>gravitee-fetcher-api</artifactId>
@@ -70,6 +70,7 @@
             <artifactId>org.eclipse.jgit</artifactId>
             <version>${org.eclipse.jgit.version}</version>
         </dependency>
+
         <!-- Spring dependencies -->
         <dependency>
             <groupId>org.springframework</groupId>
@@ -82,10 +83,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Test scope -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -126,19 +135,6 @@
             <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.22</version>
-                <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
-                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <!-- ⚠️ This plugin in used to remove a Git section forcing SSH connection instead of HTTPS  -->

--- a/pom.xml
+++ b/pom.xml
@@ -150,35 +150,48 @@
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
             </plugin>
-            <plugin>
-                <!-- ⚠️ This plugin in used to remove a Git section forcing SSH connection instead of HTTPS  -->
-                <!-- on CircleCI, for extra info see https://discuss.circleci.com/t/github-forced-through-ssh-protocol/5332 -->
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>${maven-exec-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <phase>generate-test-resources</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <skip>${env.CIRCLECI == null}</skip>
-                    <executable>git</executable>
-                    <arguments>
-                        <argument>config</argument>
-                        <argument>--global</argument>
-                        <argument>--remove-section</argument>
-                        <argument>url.ssh://git@github.com</argument>
-                    </arguments>
-                    <successCodes>
-                        <successCode>0</successCode>
-                        <successCode>1</successCode>
-                    </successCodes>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>CircleCI</id>
+            <activation>
+                <property>
+                    <name>env.CI</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <!-- ⚠️ This plugin in used to remove a Git section forcing SSH connection instead of HTTPS  -->
+                        <!-- on CircleCI, for extra info see https://discuss.circleci.com/t/github-forced-through-ssh-protocol/5332 -->
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${maven-exec-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <executable>git</executable>
+                            <arguments>
+                                <argument>config</argument>
+                                <argument>--global</argument>
+                                <argument>--remove-section</argument>
+                                <argument>url.ssh://git@github.com</argument>
+                            </arguments>
+                            <successCodes>
+                                <successCode>0</successCode>
+                                <successCode>1</successCode>
+                            </successCodes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/assembly/fetcher-assembly.xml
+++ b/src/assembly/fetcher-assembly.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/fetcher/git/GitFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/git/GitFetcher.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/fetcher/git/GitFetcherConfiguration.java
+++ b/src/main/java/io/gravitee/fetcher/git/GitFetcherConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/fetcher/git/GitFetcherConfiguration.java
+++ b/src/main/java/io/gravitee/fetcher/git/GitFetcherConfiguration.java
@@ -16,11 +16,15 @@
 package io.gravitee.fetcher.git;
 
 import io.gravitee.fetcher.api.FetcherConfiguration;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * @author Nicolas GERAUD (nicolas <AT> graviteesource.com)
  * @author GraviteeSource Team
  */
+@Getter
+@Setter
 public class GitFetcherConfiguration implements FetcherConfiguration {
 
     private String repository;
@@ -32,46 +36,4 @@ public class GitFetcherConfiguration implements FetcherConfiguration {
     private String fetchCron;
 
     private boolean autoFetch = false;
-
-    @Override
-    public String getFetchCron() {
-        return fetchCron;
-    }
-
-    public void setFetchCron(String fetchCron) {
-        this.fetchCron = fetchCron;
-    }
-
-    @Override
-    public boolean isAutoFetch() {
-        return autoFetch;
-    }
-
-    public void setAutoFetch(boolean autoFetch) {
-        this.autoFetch = autoFetch;
-    }
-
-    public String getRepository() {
-        return repository;
-    }
-
-    public void setRepository(String repository) {
-        this.repository = repository;
-    }
-
-    public String getBranchOrTag() {
-        return branchOrTag;
-    }
-
-    public void setBranchOrTag(String branchOrTag) {
-        this.branchOrTag = branchOrTag;
-    }
-
-    public String getPath() {
-        return path;
-    }
-
-    public void setPath(String path) {
-        this.path = path;
-    }
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,44 +1,40 @@
 {
-  "type": "object",
-  "title": "git",
-  "properties": {
-    "repository": {
-      "title": "Repository",
-      "description": "Web URL to the git repository",
-      "type": "string"
-    },
-    "branchOrTag": {
-      "title": "Branch or Tag",
-      "description": "Branch or tag to clone",
-      "type": "string",
-      "default": "master"
-    },
-    "path": {
-      "title": "Path",
-      "description": "Path to the file to fetch",
-      "type": "string"
-    },
-    "autoFetch": {
-      "title": "Auto Fetch",
-      "description": "Trigger periodic update",
-      "type": "boolean",
-      "default": false
-    },
-    "fetchCron": {
-      "title": "Update frequency",
-      "description": "Define update frequency using Crontab pattern.<BR><B>Note:</B> Platform administrator may have configure a max frequency that you cannot exceed",
-      "type": "string"
-    }
-  },
-  "required": [
-    "repository",
-    "branchOrTag",
-    "path"
-  ],
-  "if": {
+    "type": "object",
+    "title": "git",
     "properties": {
-      "autoFetch": { "const": true }
-    }
-  },
-  "then": { "required": ["fetchCron"] }
+        "repository": {
+            "title": "Repository",
+            "description": "Web URL to the git repository",
+            "type": "string"
+        },
+        "branchOrTag": {
+            "title": "Branch or Tag",
+            "description": "Branch or tag to clone",
+            "type": "string",
+            "default": "master"
+        },
+        "path": {
+            "title": "Path",
+            "description": "Path to the file to fetch",
+            "type": "string"
+        },
+        "autoFetch": {
+            "title": "Auto Fetch",
+            "description": "Trigger periodic update",
+            "type": "boolean",
+            "default": false
+        },
+        "fetchCron": {
+            "title": "Update frequency",
+            "description": "Define update frequency using Crontab pattern.<BR><B>Note:</B> Platform administrator may have configure a max frequency that you cannot exceed",
+            "type": "string"
+        }
+    },
+    "required": ["repository", "branchOrTag", "path"],
+    "if": {
+        "properties": {
+            "autoFetch": { "const": true }
+        }
+    },
+    "then": { "required": ["fetchCron"] }
 }

--- a/src/test/java/io/gravitee/fetcher/git/GitFetcherIntegrationTest.java
+++ b/src/test/java/io/gravitee/fetcher/git/GitFetcherIntegrationTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/fetcher/git/GitFetcherIntegrationTest.java
+++ b/src/test/java/io/gravitee/fetcher/git/GitFetcherIntegrationTest.java
@@ -22,13 +22,13 @@ import io.gravitee.fetcher.api.FetcherException;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Nicolas GERAUD (nicolas <AT> graviteesource.com)
  * @author GraviteeSource Team
  */
-public class GitFetcherIntegrationTest {
+class GitFetcherIntegrationTest {
 
     @Test
     public void shouldGetExistingFileWithBranch() throws Exception {


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4957
https://github.com/gravitee-io/issues/issues/9733

**Description**

Starting with APIM 4.3, Spring 6.1.8 is used. But in this version, the `CronSequenceGenerator` has been replaced by `CronExpression`
We need to update every fetcher libs and plugins to handle this change.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-upgrade-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/fetcher/gravitee-fetcher-git/2.0.0-upgrade-SNAPSHOT/gravitee-fetcher-git-2.0.0-upgrade-SNAPSHOT.zip)
  <!-- Version placeholder end -->
