### PR TITLE
fix(git-fetcher): delete tmp clone directory on stream close

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.17.0
+    gravitee: gravitee-io/gravitee@5.5.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.5.1</version>
+        <version>23.5.0</version>
     </parent>
 
     <groupId>io.gravitee.fetcher</groupId>

--- a/src/main/java/io/gravitee/fetcher/git/GitFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/git/GitFetcher.java
@@ -73,8 +73,7 @@ public class GitFetcher implements Fetcher {
             final Resource resource = new Resource();
             Path repositoryPath;
             try (
-                Git result = Git
-                    .cloneRepository()
+                Git result = Git.cloneRepository()
                     .setURI(this.gitFetcherConfiguration.getRepository())
                     .setDirectory(tmpDirectory)
                     .setBranch(this.gitFetcherConfiguration.getBranchOrTag())

--- a/src/main/java/io/gravitee/fetcher/git/GitFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/git/GitFetcher.java
@@ -22,6 +22,7 @@ import io.gravitee.fetcher.api.Resource;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.stream.Stream;
 import org.eclipse.jgit.api.Git;
 import org.slf4j.Logger;
@@ -66,40 +67,88 @@ public class GitFetcher implements Fetcher {
             throw new FetcherException("Unable to create temporary directory to fetch git repository", e);
         }
 
-        final Resource resource = new Resource();
-        Path repositoryPath;
-        try (
-            Git result = Git
-                .cloneRepository()
-                .setURI(this.gitFetcherConfiguration.getRepository())
-                .setDirectory(tmpDirectory)
-                .setBranch(this.gitFetcherConfiguration.getBranchOrTag())
-                .setDepth(1)
-                .call()
-        ) {
-            LOGGER.debug("Having repository: {}", result.getRepository().getDirectory());
-            repositoryPath = result.getRepository().getWorkTree().toPath();
-        } catch (Exception e) {
-            throw new FetcherException("Unable to fetch git content (" + e.getMessage() + ")", e);
-        }
-
-        try (Stream<Path> stream = Files.walk(repositoryPath)) {
-            File fileToFetch = stream
-                .filter(path -> path.endsWith(gitFetcherConfiguration.getPath()))
-                .findAny()
-                .map(Path::toFile)
-                .orElseThrow(() -> new FetcherException("Unable to find file to fetch", null));
-
-            if (Files.isSymbolicLink(fileToFetch.toPath())) {
-                checkSymbolicLinkTargetIsInsideDirectory(fileToFetch, tmpDirectory);
+        // Track whether we successfully returned a stream so the finally block can clean up on error paths.
+        boolean streamReturned = false;
+        try {
+            final Resource resource = new Resource();
+            Path repositoryPath;
+            try (
+                Git result = Git
+                    .cloneRepository()
+                    .setURI(this.gitFetcherConfiguration.getRepository())
+                    .setDirectory(tmpDirectory)
+                    .setBranch(this.gitFetcherConfiguration.getBranchOrTag())
+                    .setDepth(1)
+                    .call()
+            ) {
+                LOGGER.debug("Having repository: {}", result.getRepository().getDirectory());
+                repositoryPath = result.getRepository().getWorkTree().toPath();
+            } catch (Exception e) {
+                throw new FetcherException("Unable to fetch git content (" + e.getMessage() + ")", e);
             }
 
-            resource.setContent(new FileInputStream(fileToFetch));
-        } catch (IOException e) {
-            throw new FetcherException("Unable to walk through the repository files", e);
+            try (Stream<Path> stream = Files.walk(repositoryPath)) {
+                File fileToFetch = stream
+                    .filter(path -> path.endsWith(gitFetcherConfiguration.getPath()))
+                    .findAny()
+                    .map(Path::toFile)
+                    .orElseThrow(() -> new FetcherException("Unable to find file to fetch", null));
+
+                if (Files.isSymbolicLink(fileToFetch.toPath())) {
+                    checkSymbolicLinkTargetIsInsideDirectory(fileToFetch, tmpDirectory);
+                }
+
+                resource.setContent(new CleanupInputStream(new FileInputStream(fileToFetch), tmpDirectory));
+                streamReturned = true;
+            } catch (IOException e) {
+                throw new FetcherException("Unable to walk through the repository files", e);
+            }
+
+            return resource;
+        } finally {
+            if (!streamReturned) {
+                deleteQuietly(tmpDirectory);
+            }
+        }
+    }
+
+    static final class CleanupInputStream extends FilterInputStream {
+
+        private File tmpDirectory;
+
+        CleanupInputStream(FileInputStream in, File tmpDirectory) {
+            super(in);
+            this.tmpDirectory = tmpDirectory;
         }
 
-        return resource;
+        @Override
+        public void close() throws IOException {
+            try {
+                super.close();
+            } finally {
+                deleteQuietly(tmpDirectory);
+                tmpDirectory = null; // double-close guard
+            }
+        }
+    }
+
+    private static void deleteQuietly(File dir) {
+        if (dir == null || !dir.exists()) {
+            return;
+        }
+        try (Stream<Path> walk = Files.walk(dir.toPath())) {
+            walk
+                .sorted(Comparator.reverseOrder())
+                .forEach(p -> {
+                    try {
+                        Files.delete(p);
+                    } catch (IOException e) {
+                        LOGGER.warn("Failed to delete tmp file {}", p, e);
+                    }
+                });
+        } catch (IOException | UncheckedIOException e) {
+            LOGGER.warn("Failed to walk tmp directory for cleanup: {}", dir, e);
+        }
     }
 
     private static void checkSymbolicLinkTargetIsInsideDirectory(File symlink, File directory) throws FetcherException {

--- a/src/test/java/io/gravitee/fetcher/git/CleanupInputStreamTest.java
+++ b/src/test/java/io/gravitee/fetcher/git/CleanupInputStreamTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.fetcher.git;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CleanupInputStreamTest {
+
+    /**
+     * Verifies tmpDirectory is deleted when close() completes normally.
+     */
+    @Test
+    void shouldDeleteTmpDirectoryOnClose(@TempDir File base) throws Exception {
+        File managed = new File(base, "managed");
+        managed.mkdir();
+        File testFile = new File(managed, "file.txt");
+        testFile.createNewFile();
+
+        var stream = new GitFetcher.CleanupInputStream(new FileInputStream(testFile), managed);
+        assertThat(managed).exists();
+        stream.close();
+        assertThat(managed).doesNotExist();
+    }
+
+    /**
+     * Verifies that tmpDirectory is deleted even when super.close() throws.
+     * This is the reason the close() body uses try { super.close() } finally { delete }.
+     */
+    @Test
+    void shouldDeleteTmpDirectoryEvenWhenSuperCloseThrows(@TempDir File base) throws Exception {
+        File managed = new File(base, "managed");
+        managed.mkdir();
+        File testFile = new File(managed, "file.txt");
+        testFile.createNewFile();
+
+        FileInputStream failingStream = new FileInputStream(testFile) {
+            @Override
+            public void close() throws IOException {
+                throw new IOException("simulated close failure");
+            }
+        };
+
+        var stream = new GitFetcher.CleanupInputStream(failingStream, managed);
+        assertThatThrownBy(stream::close).isInstanceOf(IOException.class).hasMessage("simulated close failure");
+        // deletion must have run in the finally block despite the thrown exception
+        assertThat(managed).doesNotExist();
+    }
+
+    /**
+     * Verifies that calling close() a second time does not throw and does not crash.
+     * tmpDirectory is nulled after first deletion; deleteQuietly guards on null.
+     */
+    @Test
+    void shouldBeDoubleCloseSafe(@TempDir File base) throws Exception {
+        File managed = new File(base, "managed");
+        managed.mkdir();
+        File testFile = new File(managed, "file.txt");
+        testFile.createNewFile();
+
+        var stream = new GitFetcher.CleanupInputStream(new FileInputStream(testFile), managed);
+        stream.close();
+        assertThat(managed).doesNotExist();
+        assertThatCode(stream::close).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/io/gravitee/fetcher/git/GitFetcherIntegrationTest.java
+++ b/src/test/java/io/gravitee/fetcher/git/GitFetcherIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.fail;
 
 import io.gravitee.fetcher.api.FetcherException;
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import org.junit.jupiter.api.Test;
@@ -163,6 +164,51 @@ class GitFetcherIntegrationTest {
             assertThat(fetcherException.getMessage()).isEqualTo("Unable to find file to fetch");
             assertThat(is).isNull();
         }
+    }
+
+    @Test
+    public void shouldDeleteTmpDirectoryOnStreamClose() throws Exception {
+        GitFetcherConfiguration config = new GitFetcherConfiguration();
+        config.setRepository("https://github.com/gravitee-io/gravitee-fetcher-git");
+        config.setBranchOrTag("master");
+        config.setPath("pom.xml");
+
+        File[] before = listGraviteeIoTmpDirs();
+
+        try (InputStream is = new GitFetcher(config).fetch().getContent()) {
+            assertThat(is).isNotNull();
+            // tmp dir exists while stream is open
+        }
+        // after close(), CleanupInputStream should have deleted the tmp dir
+        File[] after = listGraviteeIoTmpDirs();
+        assertThat(after).hasSameSizeAs(before);
+    }
+
+    @Test
+    public void shouldDeleteTmpDirectoryOnFetchError() {
+        GitFetcherConfiguration config = new GitFetcherConfiguration();
+        config.setRepository("https://github.com/gravitee-io/gravitee-fetcher-git");
+        config.setBranchOrTag("master");
+        config.setPath("this-file-does-not-exist.txt");
+
+        File[] before = listGraviteeIoTmpDirs();
+
+        try {
+            new GitFetcher(config).fetch();
+            fail("should throw FetcherException");
+        } catch (FetcherException e) {
+            assertThat(e.getMessage()).isEqualTo("Unable to find file to fetch");
+        }
+
+        // finally block should have cleaned up the tmp dir on error path
+        File[] after = listGraviteeIoTmpDirs();
+        assertThat(after).hasSameSizeAs(before);
+    }
+
+    private static File[] listGraviteeIoTmpDirs() {
+        File tmpDir = new File(System.getProperty("java.io.tmpdir"));
+        File[] dirs = tmpDir.listFiles(f -> f.getName().startsWith("Gravitee-io") && f.isDirectory());
+        return dirs != null ? dirs : new File[0];
     }
 
     @Test

--- a/src/test/java/io/gravitee/fetcher/git/GitFetcherIntegrationTest.java
+++ b/src/test/java/io/gravitee/fetcher/git/GitFetcherIntegrationTest.java
@@ -141,8 +141,9 @@ class GitFetcherIntegrationTest {
             is = gitFetcher.fetch().getContent();
             fail("should not happen");
         } catch (FetcherException fetcherException) {
-            assertThat(fetcherException.getMessage())
-                .isEqualTo("Accessing a file outside the Git repository using symbolic links is not allowed");
+            assertThat(fetcherException.getMessage()).isEqualTo(
+                "Accessing a file outside the Git repository using symbolic links is not allowed"
+            );
             assertThat(is).isNull();
         }
     }


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-13361

## Summary

- `GitFetcher.fetch()` clones a full repo into a `/tmp/Gravitee-io*` dir then returns a `FileInputStream` into it, but never deletes the dir. Every fetch leaks a temp dir on disk permanently.
- Wraps the returned stream in `CleanupInputStream extends FilterInputStream`. Its `close()` uses `try/finally` to recursively delete the tmp clone dir via `deleteQuietly()`.
- Error paths (clone failure, file not found, symlink check, FileInputStream ctor) are covered by a `streamReturned` flag + outer `finally` that calls `deleteQuietly` if the stream was never handed off.
- `deleteQuietly` catches both `IOException` and `UncheckedIOException`, logs WARN, never propagates.
- Double-close safe: `tmpDirectory` field nulled after first deletion.

Fixes APIM-13361
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-fix-APIM-13361-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/fetcher/gravitee-fetcher-git/3.0.0-fix-APIM-13361-SNAPSHOT/gravitee-fetcher-git-3.0.0-fix-APIM-13361-SNAPSHOT.zip)
  <!-- Version placeholder end -->
