### PR TITLE
fix: normalize path and clarify not-found error

### DIFF
--- a/src/main/java/io/gravitee/fetcher/git/GitFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/git/GitFetcher.java
@@ -19,6 +19,7 @@ import io.gravitee.fetcher.api.Fetcher;
 import io.gravitee.fetcher.api.FetcherConfiguration;
 import io.gravitee.fetcher.api.FetcherException;
 import io.gravitee.fetcher.api.Resource;
+import io.gravitee.fetcher.api.ResourceNotFoundException;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -59,6 +60,11 @@ public class GitFetcher implements Fetcher {
             }
         }
 
+        final String normalizedPath = normalizePath(gitFetcherConfiguration.getPath());
+        if (normalizedPath.isEmpty()) {
+            throw new FetcherException("Unable to fetch git content: the path to the file to fetch is missing", null);
+        }
+
         File tmpDirectory;
         try {
             tmpDirectory = File.createTempFile("Gravitee-io", "");
@@ -88,10 +94,10 @@ public class GitFetcher implements Fetcher {
 
             try (Stream<Path> stream = Files.walk(repositoryPath)) {
                 File fileToFetch = stream
-                    .filter(path -> path.endsWith(gitFetcherConfiguration.getPath()))
+                    .filter(path -> path.endsWith(normalizedPath))
                     .findAny()
                     .map(Path::toFile)
-                    .orElseThrow(() -> new FetcherException("Unable to find file to fetch", null));
+                    .orElseThrow(() -> new ResourceNotFoundException(buildNotFoundMessage(), null));
 
                 if (Files.isSymbolicLink(fileToFetch.toPath())) {
                     checkSymbolicLinkTargetIsInsideDirectory(fileToFetch, tmpDirectory);
@@ -109,6 +115,34 @@ public class GitFetcher implements Fetcher {
                 deleteQuietly(tmpDirectory);
             }
         }
+    }
+
+    /** Accepts both path forms (with or without leading slash); never persisted back to the configuration. */
+    private static String normalizePath(String path) {
+        return path == null ? "" : path.trim().replaceAll("^/+", "");
+    }
+
+    private String buildNotFoundMessage() {
+        String ref = gitFetcherConfiguration.getBranchOrTag() == null || gitFetcherConfiguration.getBranchOrTag().isEmpty()
+            ? "default branch"
+            : gitFetcherConfiguration.getBranchOrTag();
+        return (
+            "Unable to find file '" +
+            gitFetcherConfiguration.getPath() +
+            "' in repository '" +
+            sanitizeRepository(gitFetcherConfiguration.getRepository()) +
+            "' (ref: " +
+            ref +
+            ")"
+        );
+    }
+
+    /**
+     * This plugin has no dedicated credential field, so the repository URL commonly embeds them
+     * (https://user:token@host/...). Strip the userinfo part before the URL reaches an error message.
+     */
+    static String sanitizeRepository(String repository) {
+        return repository == null ? "" : repository.replaceFirst("^([a-zA-Z][a-zA-Z0-9+.\\-]*://)[^/@]*@", "$1");
     }
 
     static final class CleanupInputStream extends FilterInputStream {

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -15,8 +15,8 @@
             "default": "master"
         },
         "path": {
-            "title": "Path",
-            "description": "Path to the file to fetch",
+            "title": "Filepath",
+            "description": "The path to the file to fetch (e.g. docs/main/README.md)",
             "type": "string"
         },
         "autoFetch": {

--- a/src/test/java/io/gravitee/fetcher/git/GitFetcherIntegrationTest.java
+++ b/src/test/java/io/gravitee/fetcher/git/GitFetcherIntegrationTest.java
@@ -86,7 +86,9 @@ class GitFetcherIntegrationTest {
             is = gitFetcher.fetch().getContent();
             fail("should not happen");
         } catch (FetcherException fetcherException) {
-            assertThat(fetcherException.getMessage()).isEqualTo("Unable to find file to fetch");
+            assertThat(fetcherException.getMessage()).isEqualTo(
+                "Unable to find file 'unknown' in repository 'https://github.com/gravitee-io/gravitee-fetcher-git' (ref: master)"
+            );
             assertThat(is).isNull();
         }
     }
@@ -162,7 +164,9 @@ class GitFetcherIntegrationTest {
             is = gitFetcher.fetch().getContent();
             fail("should not happen");
         } catch (FetcherException fetcherException) {
-            assertThat(fetcherException.getMessage()).isEqualTo("Unable to find file to fetch");
+            assertThat(fetcherException.getMessage()).isEqualTo(
+                "Unable to find file '/root-symlink/ssh_config' in repository 'https://github.com/gravitee-io/gravitee-fetcher-git' (ref: master)"
+            );
             assertThat(is).isNull();
         }
     }
@@ -198,7 +202,9 @@ class GitFetcherIntegrationTest {
             new GitFetcher(config).fetch();
             fail("should throw FetcherException");
         } catch (FetcherException e) {
-            assertThat(e.getMessage()).isEqualTo("Unable to find file to fetch");
+            assertThat(e.getMessage()).isEqualTo(
+                "Unable to find file 'this-file-does-not-exist.txt' in repository 'https://github.com/gravitee-io/gravitee-fetcher-git' (ref: master)"
+            );
         }
 
         // finally block should have cleaned up the tmp dir on error path

--- a/src/test/java/io/gravitee/fetcher/git/GitFetcherPathNormalizationTest.java
+++ b/src/test/java/io/gravitee/fetcher/git/GitFetcherPathNormalizationTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.fetcher.git;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.fetcher.api.FetcherException;
+import io.gravitee.fetcher.api.ResourceNotFoundException;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class GitFetcherPathNormalizationTest {
+
+    @TempDir
+    static Path repositoryDirectory;
+
+    static String repositoryUri;
+    static String branch;
+
+    @BeforeAll
+    static void create_local_repository() throws Exception {
+        try (Git git = Git.init().setDirectory(repositoryDirectory.toFile()).call()) {
+            Files.writeString(repositoryDirectory.resolve("README.md"), "root readme");
+            Files.createDirectories(repositoryDirectory.resolve("docs"));
+            Files.writeString(repositoryDirectory.resolve("docs").resolve("page.md"), "docs page");
+
+            git.add().addFilepattern(".").call();
+            PersonIdent committer = new PersonIdent("Gravitee Test", "test@gravitee.io");
+            git.commit().setMessage("init").setAuthor(committer).setCommitter(committer).setSign(false).call();
+
+            branch = git.getRepository().getBranch();
+            repositoryUri = repositoryDirectory.toUri().toString();
+        }
+    }
+
+    @Test
+    void should_fetch_file_when_path_has_leading_slash() throws Exception {
+        GitFetcher fetcher = new GitFetcher(configuration("/README.md"));
+
+        assertThat(readAll(fetcher.fetch().getContent())).isEqualTo("root readme");
+    }
+
+    @Test
+    void should_throw_explicit_error_when_file_does_not_exist() {
+        GitFetcher fetcher = new GitFetcher(configuration("docs/unknown.md"));
+
+        assertThatThrownBy(fetcher::fetch)
+            .isInstanceOf(ResourceNotFoundException.class)
+            .hasMessage("Unable to find file 'docs/unknown.md' in repository '" + repositoryUri + "' (ref: " + branch + ")");
+    }
+
+    @Test
+    void should_strip_credentials_embedded_in_the_repository_url() {
+        assertThat(GitFetcher.sanitizeRepository("https://user:s3cr3t-token@example.org/org/repo.git")).isEqualTo(
+            "https://example.org/org/repo.git"
+        );
+    }
+
+    @Test
+    void should_leave_repository_url_untouched_when_it_carries_no_credentials() {
+        assertThat(GitFetcher.sanitizeRepository("https://example.org/org/repo.git")).isEqualTo("https://example.org/org/repo.git");
+        assertThat(GitFetcher.sanitizeRepository("git@example.org:org/repo.git")).isEqualTo("git@example.org:org/repo.git");
+    }
+
+    @Test
+    void should_throw_explicit_error_when_path_is_only_a_slash() {
+        GitFetcher fetcher = new GitFetcher(configuration("/"));
+
+        assertThatThrownBy(fetcher::fetch)
+            .isInstanceOf(FetcherException.class)
+            .hasMessage("Unable to fetch git content: the path to the file to fetch is missing");
+    }
+
+    private static GitFetcherConfiguration configuration(String path) {
+        GitFetcherConfiguration configuration = new GitFetcherConfiguration();
+        configuration.setRepository(repositoryUri);
+        configuration.setBranchOrTag(branch);
+        configuration.setPath(path);
+        return configuration;
+    }
+
+    private static String readAll(InputStream inputStream) throws Exception {
+        try (InputStream is = inputStream) {
+            return new String(is.readAllBytes());
+        }
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/PORTAL-55

**Description**

Documentation fetchers handled the filepath leading slash inconsistently (one form worked, the other failed with an opaque error, and the rule differed between plugins). Align this plugin with the others: accept the filepath with or without a leading slash, and raise an explicit not-found error (file, repository, ref) when the file does not exist.

**Note**

Raising `ResourceNotFoundException` means APIM now deletes the page from the database when the file is missing at auto-fetch time (`PageServiceImpl#fetch`), aligning Git with the other fetchers.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.1-fix-doc-filepath-normalization-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/fetcher/gravitee-fetcher-git/3.0.1-fix-doc-filepath-normalization-SNAPSHOT/gravitee-fetcher-git-3.0.1-fix-doc-filepath-normalization-SNAPSHOT.zip)
  <!-- Version placeholder end -->

